### PR TITLE
Refactoring Kryp

### DIFF
--- a/cmd/kryp/main.go
+++ b/cmd/kryp/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/monzo/kryp/pkg/diff"
 	"github.com/monzo/kryp/pkg/k8s"
+	"k8s.io/client-go/rest"
 )
 
 var (
@@ -19,12 +20,15 @@ var (
 )
 
 func main() {
+
 	if home := homeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
+
 	colorDisabled := flag.Bool("no-color", false, "Disables ANSI colour output")
+
 	flag.Parse()
 	args := flag.Args()
 
@@ -34,32 +38,40 @@ func main() {
 		flag.Usage()
 		fatal("Error: requires positional argument for directory/file to check")
 	}
-	log.SetOutput(ioutil.Discard)
-
-	filename := args[0]
 
 	config, err := k8s.LoadConfig(*kubeconfig)
 	if err != nil {
 		fatal("error: %f", err)
 	}
 
+	if deltas := scanForChanges(args[0], config); deltas > 0 {
+		os.Exit(2)
+	}
+}
+
+func scanForChanges(filename string, config *rest.Config) int {
+
 	helper, err := k8s.NewResourceHelperWithDefaults(config)
 	if err != nil {
 		fatal("error: %f", err)
 	}
-	changesPresent := false
 
+	log.SetOutput(ioutil.Discard)
+
+	totalDeltas := 0
 	filepath.Walk(filename, func(fp string, fi os.FileInfo, err error) error {
+
 		if err != nil {
 			fmt.Println(err) // can't walk here,
-			return nil       // but continue walking elsewhere
+			return nil
 		}
+
 		if fi.IsDir() {
-			return nil // not a file.  ignore.
+			return nil // not a file. ignore.
 		}
 
 		if !strings.HasSuffix(fi.Name(), ".yaml") {
-			fmt.Printf("Ignoring %s as it doesn't end in .yaml\n", fp)
+			//fmt.Printf("Ignoring %s as it doesn't end in .yaml\n", fp)
 			return nil
 		}
 
@@ -70,6 +82,8 @@ func main() {
 		}
 
 		for _, r := range resources {
+			changesPresent := false
+
 			d, err := diff.GetDiffsForResource(r, helper)
 			if err != nil {
 				fmt.Printf("Error getting resource: %v\n", err)
@@ -82,25 +96,24 @@ func main() {
 				status = "not found on server"
 				changesPresent = true
 			case diff.ChangesPresentDiff:
-				status = fmt.Sprintf("%d changes", len(d.Deltas()))
-				if len(d.Deltas()) > 0 {
+				if deltas := len(d.Deltas()); deltas > 0 {
 					changesPresent = true
+					status = fmt.Sprintf("%d changes", deltas)
 				}
 			}
-			kind := r.Object.GetObjectKind().GroupVersionKind().Kind
-			ref := fmt.Sprintf("%s/%s", r.Namespace, r.Name)
-			fmt.Printf("%-50s %-25s %-50s: %s\n", ref, kind, fp, status)
+
 			if changesPresent {
+				kind := r.Object.GetObjectKind().GroupVersionKind().Kind
+				ref := fmt.Sprintf("%s/%s", r.Namespace, r.Name)
+				fmt.Printf("%-50s %-25s %-50s: %s\n", ref, kind, fp, status)
 				fmt.Println(d.Pretty(colorEnabled))
+				totalDeltas++
 			}
 		}
 		return nil
 	})
 
-	if changesPresent {
-		os.Exit(2)
-	}
-
+	return totalDeltas
 }
 
 func fatal(msg string, args ...interface{}) {

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -4,43 +4,47 @@ import (
 	"log"
 
 	"github.com/monzo/kryp/pkg/k8s"
-
-	_ "k8s.io/kubernetes/pkg/master"
+	//_ "k8s.io/kubernetes/pkg/master"
 )
 
+// GetDiffsForResource takes a resource, and uses to generate a local Kubernetes object
+// which it compares to the equivalent object fetched from the cluster
 func GetDiffsForResource(resource *k8s.Resource, helper *k8s.ResourceHelper) (Diff, error) {
-	log.Printf("Setting defaults for object %v", resource.Object)
+
+	// Create a Kubernetes object from the file
 	defaultedObj := k8s.GetWithDefaults(resource.Object)
 	meta := DiffMeta{Resource: resource}
 
+	// Get the Kubernetes object from the server
 	serverObj, err := resource.Get()
-	if k8s.IsNotFoundError(err) {
-		return NotPresentOnServerDiff{DiffMeta: meta}, nil
-	}
 	if err != nil {
+		if k8s.IsNotFoundError(err) {
+			return NotPresentOnServerDiff{DiffMeta: meta}, nil
+		}
+
 		log.Printf("Error getting object: %v", err)
 		return ChangesPresentDiff{}, err
 	}
 
+	// Compare the File and Server Objects
 	deltas, err := calculateDiff(defaultedObj, serverObj)
 	if err != nil {
 		log.Printf("Error calculating deltas: %v", err)
 		return ChangesPresentDiff{}, err
 	}
 
+	// Some deltas are to be expected, so we filter them
 	filtered := deltas
 	for _, f := range []DeltaFilter{MetadataFilter} {
 		filtered = f(filtered)
 	}
 
 	log.Printf("Found %d deltas", len(deltas))
-
 	return ChangesPresentDiff{DiffMeta: meta, deltas: filtered}, nil
 }
 
 var empty = struct{}{}
 
-func (d ChangesPresentDiff) Deltas() []Delta { return d.deltas }
-
+func (d ChangesPresentDiff) Deltas() []Delta                     { return d.deltas }
 func (d NotPresentOnServerDiff) Pretty(colorEnabled bool) string { return "" }
 func (d NotPresentOnServerDiff) Deltas() []Delta                 { return []Delta{} }

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -4,7 +4,6 @@ import (
 	"log"
 
 	"github.com/monzo/kryp/pkg/k8s"
-	//_ "k8s.io/kubernetes/pkg/master"
 )
 
 // GetDiffsForResource takes a resource, and uses to generate a local Kubernetes object
@@ -35,7 +34,7 @@ func GetDiffsForResource(resource *k8s.Resource, helper *k8s.ResourceHelper) (Di
 
 	// Some deltas are to be expected, so we filter them
 	filtered := deltas
-	for _, f := range []DeltaFilter{MetadataFilter} {
+	for _, f := range []DeltaFilter{metadataFilter} {
 		filtered = f(filtered)
 	}
 

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -33,13 +33,10 @@ func GetDiffsForResource(resource *k8s.Resource, helper *k8s.ResourceHelper) (Di
 	}
 
 	// Some deltas are to be expected, so we filter them
-	filtered := deltas
-	for _, f := range []DeltaFilter{metadataFilter} {
-		filtered = f(filtered)
-	}
+	filteredDeltas := metadataFilter(deltas)
 
 	log.Printf("Found %d deltas", len(deltas))
-	return ChangesPresentDiff{DiffMeta: meta, deltas: filtered}, nil
+	return ChangesPresentDiff{DiffMeta: meta, deltas: filteredDeltas}, nil
 }
 
 var empty = struct{}{}

--- a/pkg/diff/filters.go
+++ b/pkg/diff/filters.go
@@ -7,28 +7,41 @@ import (
 type DeltaFilter func([]Delta) []Delta
 
 var sourceRes = []*regexp.Regexp{
+	regexp.MustCompile(`apiVersion`),
+	regexp.MustCompile(`status.*`),
+	regexp.MustCompile(`kind`),
+	regexp.MustCompile(`metadata\.creationTimestamp`),
+	regexp.MustCompile(`spec\.jobTemplate\.spec\.backoffLimit`),
 	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.hostPath\.type`),
 }
+
 var serverRes = []*regexp.Regexp{
-	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.emptyDir\.sizeLimit`),
-	regexp.MustCompile(`spec\.ports\.[0-9]+\.nodePort`),
 	regexp.MustCompile(`status.*`),
+	regexp.MustCompile(`metadata\.(generation|selfLink|resourceVersion|uid)`),
+	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.emptyDir\.sizeLimit`),
+	regexp.MustCompile(`spec\.template\.spec\.serviceAccount`),
+	regexp.MustCompile(`spec\.ports\.[0-9]+\.nodePort`),
+	regexp.MustCompile(`spec\.(clusterIP|volumeName)`),
+	regexp.MustCompile(`secrets`),
 }
 
+// This function receives a diff between the source and server for a sepcific key
+// and returns whether we should care about the delta
+//
+// Examples:
+//   We don't care about this:
+//   Source:  {metadata.creationTimestamp <nil>}
+//   Server:  {metadata.creationTimestamp 2018-10-15T13:21:32Z}
+//
+//   We do care about this:
+//   Source:  {spec.template.spec.containers.1.image 442690283804.dkr.ecr.eu-west-1.amazonaws.com/monzo/kryp:21069d0}
+//   Server:  {spec.template.spec.containers.1.image 442690283804.dkr.ecr.eu-west-1.amazonaws.com/monzo/kryp:1b1d0b3}
+//
 func shouldKeepMetadata(d Delta) bool {
 
-	// Items to ignore in the source control files
-	switch d.SourceItem.Key {
-	case "apiVersion",
-		"kind",
-		"status.phase",
-		"metadata.creationTimestamp",
-		"metadata.namespace",
-		"spec.jobTemplate.spec.backoffLimit":
-		return false
-	}
+	//fmt.Printf("Source: %v\nServer: %v\n\n", d.SourceItem, d.ServerItem)
 
-	// As above but looking at the source regex's
+	// Items to ignore in the source control files
 	for _, re := range sourceRes {
 		if re.MatchString(d.SourceItem.Key) {
 			return false
@@ -37,15 +50,6 @@ func shouldKeepMetadata(d Delta) bool {
 
 	// Items to ignore from the kubernetes API server
 	switch d.ServerItem.Key {
-	case "metadata.generation",
-		"metadata.selfLink",
-		"metadata.resourceVersion",
-		"metadata.uid",
-		"spec.clusterIP",
-		"secrets",
-		"spec.volumeName",
-		"spec.template.spec.serviceAccount":
-		return false
 	case "metadata.annotations":
 		anns, ok := d.ServerItem.Value.(map[string]interface{})
 		if ok && anns["kubectl.kubernetes.io/last-applied-configuration"] != struct{}{} {
@@ -62,7 +66,7 @@ func shouldKeepMetadata(d Delta) bool {
 	return true
 }
 
-func MetadataFilter(deltas []Delta) []Delta {
+func metadataFilter(deltas []Delta) []Delta {
 	var filtered []Delta
 	for _, d := range deltas {
 		if shouldKeepMetadata(d) {

--- a/pkg/diff/filters.go
+++ b/pkg/diff/filters.go
@@ -8,11 +8,11 @@ type DeltaFilter func([]Delta) []Delta
 
 var sourceRes = []*regexp.Regexp{
 	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.hostPath\.type`),
-	regexp.MustCompile(`spec\.selector\.matchLabels\..+`),
-	regexp.MustCompile(`spec\.ports\.[0-9]+\.nodePort`),
 }
 var serverRes = []*regexp.Regexp{
 	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.emptyDir\.sizeLimit`),
+	regexp.MustCompile(`spec\.ports\.[0-9]+\.nodePort`),
+	regexp.MustCompile(`status.*`),
 }
 
 func shouldKeepMetadata(d Delta) bool {

--- a/pkg/diff/filters.go
+++ b/pkg/diff/filters.go
@@ -9,6 +9,7 @@ type DeltaFilter func([]Delta) []Delta
 var sourceRes = []*regexp.Regexp{
 	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.hostPath\.type`),
 	regexp.MustCompile(`spec\.selector\.matchLabels\..+`),
+	regexp.MustCompile(`spec\.ports\.[0-9]+\.nodePort`),
 }
 var serverRes = []*regexp.Regexp{
 	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.emptyDir\.sizeLimit`),

--- a/pkg/k8s/resource_helper.go
+++ b/pkg/k8s/resource_helper.go
@@ -10,10 +10,9 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/util/yaml"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -208,7 +207,7 @@ func (rh *ResourceHelper) buildGETRequestFor(r *Resource, export bool) (*rest.Re
 }
 
 func (rh *ResourceHelper) Get(r *Resource) (runtime.Object, error) {
-	req, err := rh.buildGETRequestFor(r, true)
+	req, err := rh.buildGETRequestFor(r, false)
 	if err != nil {
 		return &v1.List{}, err
 	}
@@ -268,9 +267,6 @@ func (rh *ResourceHelper) Delete(r *Resource) error {
 }
 
 func IsNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
 	st, ok := err.(*errors.StatusError)
 	if ok {
 		return st.Status().Reason == "NotFound"


### PR DESCRIPTION
Just some minor refactoring to make it (I hope) easier to follow what's going on.  Notable changes:
- Getting objects in 'export' mode was dropping some fields we care about.  We now get the full object from the server so we can control what we filter.
- Split the big main() function into `main` (setup, parse cmd line) and `scanForChanges` which does the actual diffing.
- Add flag to only log deltas.  Files with 0 changes are typically not useful.
- Unify the filters into one list.  The effect is the same, but I think it's clearer like this for future changes.
