### PR TITLE
Rename the label for the object's namespace

### DIFF
--- a/cmd/kontrastd/manager.go
+++ b/cmd/kontrastd/manager.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	objectLabel = "object"
-	nsLabel     = "namespace"
+	nsLabel     = "object_ns"
 )
 
 type DiffManager struct {


### PR DESCRIPTION
`namespace` is a special value in Prometheus land.