### PR TITLE
Remove noisy logging line

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -35,7 +35,6 @@ func GetDiffsForResource(resource *k8s.Resource, helper *k8s.ResourceHelper) (Di
 	// Some deltas are to be expected, so we filter them
 	filteredDeltas := metadataFilter(deltas)
 
-	log.Printf("Found %d deltas", len(deltas))
 	return ChangesPresentDiff{DiffMeta: meta, deltas: filteredDeltas}, nil
 }
 


### PR DESCRIPTION
In kontrastd, this logs for every single resource it diffs, which adds a
lot of noise to kubediff logs.