### PR TITLE
Fix kontrast failing for invalid Secrets

### DIFF
--- a/pkg/k8s/resource_helper.go
+++ b/pkg/k8s/resource_helper.go
@@ -89,7 +89,9 @@ func (rh *ResourceHelper) NewResourcesFromFilename(filename string) ([]*Resource
 			return []*Resource{}, fmt.Errorf("deserialise resource %s: %s", filename, err.Error())
 		}
 
-		resources = append(resources, res)
+		if res != nil {
+			resources = append(resources, res)
+		}
 	}
 }
 
@@ -101,6 +103,11 @@ func (rh *ResourceHelper) NewResourceFromBytes(bytes []byte) (*Resource, error) 
 	// K8s deserialiser does all the hard work for us here - figures out
 	// format, API group, kind, version
 	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(bytes, nil, nil)
+
+	// A missing `Kind` most probably meant an empty document
+	if runtime.IsMissingKind(err) {
+		return nil, nil
+	}
 
 	if err != nil {
 		return &Resource{}, fmt.Errorf("parse resource from bytes: %s", err.Error())

--- a/pkg/k8s/resource_helper.go
+++ b/pkg/k8s/resource_helper.go
@@ -109,6 +109,13 @@ func (rh *ResourceHelper) NewResourceFromBytes(bytes []byte) (*Resource, error) 
 		return nil, nil
 	}
 
+	// Base64 errors are most often caused by having dummy passwords in Secret files.
+	// A `fmt.Errorf` in the call stack removed the type, so this is all there is left.
+	// Check for `base64.CorruptInputError` if possible.
+	if strings.Contains(err.Error(), "illegal base64 data at input byte") {
+		return nil, nil
+	}
+
 	if err != nil {
 		return &Resource{}, fmt.Errorf("parse resource from bytes: %s", err.Error())
 	}


### PR DESCRIPTION
Dummy passwords in Secret files fail with base64 decode errors, ignore them.