### PR TITLE
Rework diff and minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+.idea

--- a/cmd/kontrast/main.go
+++ b/cmd/kontrast/main.go
@@ -20,13 +20,14 @@ var (
 )
 
 func main() {
-
-	if home := homeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	defaultKubeConfig := os.Getenv("KUBECONFIG")
+	if defaultKubeConfig == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			defaultKubeConfig = filepath.Join(home, ".kube", "config")
+		}
 	}
 
+	kubeconfig = flag.String("kubeconfig", defaultKubeConfig, "(optional) absolute path to the kubeconfig file")
 	colorDisabled := flag.Bool("no-color", false, "Disables ANSI colour output")
 	onlyShowDeltas := flag.Bool("deltas-only", true, "Only show files with changes")
 
@@ -118,11 +119,4 @@ func scanForChanges(filename string, config *rest.Config, onlyShowDeltas bool) i
 func fatal(msg string, args ...interface{}) {
 	fmt.Printf(msg+"\n", args)
 	os.Exit(1)
-}
-
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
 }

--- a/cmd/kontrast/main.go
+++ b/cmd/kontrast/main.go
@@ -46,6 +46,8 @@ func main() {
 		fatal("error: %f", err)
 	}
 
+	fmt.Println()
+
 	if deltas := scanForChanges(args[0], config, *onlyShowDeltas); deltas > 0 {
 		os.Exit(2)
 	}
@@ -105,7 +107,7 @@ func scanForChanges(filename string, config *rest.Config, onlyShowDeltas bool) i
 			if !onlyShowDeltas || changesPresent {
 				kind := r.Object.GetObjectKind().GroupVersionKind().Kind
 				ref := fmt.Sprintf("%s/%s", r.Namespace, r.Name)
-				fmt.Printf("%-50s %-25s %-50s: %s\n", ref, kind, fp, status)
+				fmt.Printf("%-50s %-25s %-50s: %s\n\n", ref, kind, fp, status)
 				fmt.Println(d.Pretty(colorEnabled))
 				totalDeltas++
 			}

--- a/cmd/kontrast/main.go
+++ b/cmd/kontrast/main.go
@@ -117,6 +117,6 @@ func scanForChanges(filename string, config *rest.Config, onlyShowDeltas bool) i
 }
 
 func fatal(msg string, args ...interface{}) {
-	fmt.Printf(msg+"\n", args)
+	fmt.Printf(msg+"\n", args...)
 	os.Exit(1)
 }

--- a/cmd/kontrastd/main.go
+++ b/cmd/kontrastd/main.go
@@ -20,11 +20,14 @@ var (
 )
 
 func main() {
-	if home := homeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	defaultKubeConfig := os.Getenv("KUBECONFIG")
+	if defaultKubeConfig == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			defaultKubeConfig = filepath.Join(home, ".kube", "config")
+		}
 	}
+
+	kubeconfig = flag.String("kubeconfig", defaultKubeConfig, "(optional) absolute path to the kubeconfig file")
 
 	flag.Parse()
 	args := flag.Args()
@@ -67,11 +70,4 @@ func main() {
 
 	log.Infof("Listening on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
-}
-
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
 }

--- a/cmd/kontrastd/manager.go
+++ b/cmd/kontrastd/manager.go
@@ -71,7 +71,7 @@ func (dm *DiffManager) processFile(path string) File {
 	k8sResources, err := dm.ResourceHelper.NewResourcesFromFilename(path)
 
 	if err != nil {
-		log.Error("Error getting resources: %v\n", err)
+		log.Errorf("Error getting resources: %v\n", err)
 		return File{
 			Name:       path,
 			DiffResult: ErrorDiffStatus(err.Error()),

--- a/pkg/diff/printer.go
+++ b/pkg/diff/printer.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -11,10 +12,10 @@ import (
 )
 
 const (
-	green = "\u001b[32m"
-	cyan  = "\u001b[36m"
-	red   = "\u001b[31m"
-	reset = "\u001b[0m"
+	green  = "\u001b[32m"
+	yellow = "\u001b[33m"
+	red    = "\u001b[31m"
+	reset  = "\u001b[0m"
 )
 
 func (i Item) Pretty() string {
@@ -25,7 +26,7 @@ func (i Item) Pretty() string {
 }
 
 func (d ChangesPresentDiff) Pretty(colorEnabled bool) string {
-	var maxLeft, maxRight int
+	var padding int
 
 	terminalWidth, _, err := terminal.GetSize(int(os.Stdin.Fd()))
 	if err != nil {
@@ -34,38 +35,31 @@ func (d ChangesPresentDiff) Pretty(colorEnabled bool) string {
 	}
 
 	for _, delta := range d.Deltas() {
-		l := len(delta.SourceItem.Pretty())
-		if l < terminalWidth/2 && l > maxLeft {
-			maxLeft = l
-		}
-
-		r := len(delta.ServerItem.Pretty())
-		if r < terminalWidth/2 && r > maxRight {
-			maxRight = r
+		l := len(delta.Key())
+		if l < terminalWidth/2 && l > padding {
+			padding = l
 		}
 	}
 
-	prettyStr := ""
+	printer := colorPrinter{colorEnabled: colorEnabled}
+
+	prettyStr := bytes.NewBuffer(nil)
 	for _, delta := range d.Deltas() {
 		sourceVal := strOrRepr(delta.SourceItem.Value)
 		serverVal := strOrRepr(delta.ServerItem.Value)
 		if multilineString(sourceVal) || multilineString(serverVal) {
 			dmp := diffmatchpatch.New()
-			diffs := dmp.DiffMain(sourceVal, serverVal, false)
-			prettyStr += dmp.DiffPrettyText(diffs)
+			diffs := dmp.DiffMain(serverVal, sourceVal, false)
+			prettyStr.WriteString(dmp.DiffPrettyText(diffs))
 		} else {
-			prettyStr += fmt.Sprintf(
-				"%s %-*s | %-*s",
-				delta.getPrettyLineStart(colorEnabled),
-				maxLeft, delta.SourceItem.Pretty(),
-				maxRight, delta.ServerItem.Pretty(),
-			)
+			prettyStr.WriteString(delta.DiffString(printer, padding))
 		}
+		prettyStr.WriteRune('\n')
 	}
 	if colorEnabled {
-		prettyStr += reset
+		prettyStr.WriteString(reset)
 	}
-	return prettyStr
+	return prettyStr.String()
 }
 
 func strOrRepr(v interface{}) string {
@@ -80,21 +74,32 @@ func multilineString(s string) bool {
 	return strings.Index(s, "\n") != -1
 }
 
-func (d Delta) getPrettyLineStart(colorEnabled bool) string {
-	gutterChar := ""
-	lineColor := ""
+func (d Delta) DiffString(printer colorPrinter, padding int) string {
 	if (d.SourceItem != Item{} && d.ServerItem == Item{}) {
-		gutterChar = "+"
-		lineColor = green
+		return printer.Print(green, fmt.Sprintf("+ %-*s: %q", padding, d.Key(), d.SourceItem.Value))
 	} else if (d.SourceItem != Item{} && d.ServerItem != Item{}) {
-		gutterChar = "~"
-		lineColor = cyan
+		return printer.Print(
+			yellow,
+			fmt.Sprintf("~ %-*s: %s => %s",
+				padding, d.Key(),
+				printer.Print(red, fmt.Sprintf("%q", d.ServerItem.Value)),
+				printer.Print(green, fmt.Sprintf("%q", d.SourceItem.Value)),
+			),
+		)
 	} else if (d.SourceItem == Item{} && d.ServerItem != Item{}) {
-		gutterChar = "-"
-		lineColor = red
+		return printer.Print(red, fmt.Sprintf("- %-*s: %q", padding, d.Key(), d.ServerItem.Value))
+	} else {
+		panic("comparing two empty items, this should not happen")
 	}
-	if !colorEnabled {
-		lineColor = ""
+}
+
+type colorPrinter struct {
+	colorEnabled bool
+}
+
+func (c colorPrinter) Print(color string, str string) string {
+	if !c.colorEnabled {
+		return str
 	}
-	return fmt.Sprintf("%s%s", lineColor, gutterChar)
+	return fmt.Sprintf("%s%s%s", color, str, reset)
 }

--- a/pkg/diff/types.go
+++ b/pkg/diff/types.go
@@ -12,6 +12,13 @@ type Delta struct {
 	ServerItem Item
 }
 
+func (d Delta) Key() string {
+	if d.SourceItem.Key != "" {
+		return d.SourceItem.Key
+	}
+	return d.ServerItem.Key
+}
+
 type Diff interface {
 	Deltas() []Delta
 	Pretty(colorEnabled bool) string

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -17,7 +17,7 @@ func LoadConfig(kubeconfig string) (*rest.Config, error) {
 	config, err := rest.InClusterConfig()
 
 	if err != nil {
-		log.Warn("In cluster config not successful, trying out of cluster config (error: %v)", err)
+		log.Warnf("In cluster config not successful, trying out of cluster config (error: %v)", err)
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
 			return config, err


### PR DESCRIPTION
## What

* Get the kube config path from the KUBECONFIG env var
* Fix error message parameter handling (wrong log.* call or extra parameters)
* Make the diff more readable and change the diff direction

For me it's confusing that we are not showing what is the diff to be applied.
I made some coloring changes:
 - red values would be deleted or show old values
 - green values are new values
 - yellow shows a key is changed

The keys won't be duplicated anymore so it's easier to see what changes.
Also values changes are easier to see with the old => new format (red and green color respectively).
