### PR TITLE
Use a dynamic collector within Kontrast

### DIFF
--- a/cmd/kontrastd/collector.go
+++ b/cmd/kontrastd/collector.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	objectLabel = "object"
+	nsLabel     = "object_ns"
+)
+
+var (
+	currentDiffsGauge = prometheus.NewDesc(
+		"kontrast_current_diffs",
+		"Number of diffs between manifests and cluster",
+		[]string{objectLabel, nsLabel}, nil)
+)
+
+// KontrastCollector is here to satisfy the Prometheus Collector interface
+type KontrastCollector struct {
+	manager *DiffManager
+}
+
+func NewKontrastCollector(manager *DiffManager) *KontrastCollector {
+	return &KontrastCollector{
+		manager: manager,
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector to the provided channel and returns once
+// the last descriptor has been sent.
+func (c *KontrastCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- currentDiffsGauge
+}
+
+// Collect is called by the Prometheus registry when collecting
+// metrics. The implementation sends each collected metric via the
+// provided channel and returns once the last metric has been sent.
+func (c *KontrastCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, file := range c.manager.GetDiffFiles() {
+		for _, resource := range file.Resources {
+			if resource.DiffResult.Status == DiffPresent {
+				objectLabel := fmt.Sprintf("%s/%s", resource.Kind, resource.Name)
+				ch <- prometheus.MustNewConstMetric(currentDiffsGauge,
+					prometheus.GaugeValue, 1.0,
+					objectLabel, resource.Namespace)
+			}
+		}
+	}
+}

--- a/cmd/kontrastd/main.go
+++ b/cmd/kontrastd/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/monzo/kontrast/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -51,6 +52,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("error: %f", err)
 	}
+
+	// Set up the Prometheus collector
+	collector := NewKontrastCollector(dm)
+	prometheus.MustRegister(collector)
 
 	go dm.DiffRun(filename)
 	updateTicker := time.NewTicker(intervalDuration)

--- a/cmd/kontrastd/manager.go
+++ b/cmd/kontrastd/manager.go
@@ -80,7 +80,7 @@ func (dm *DiffManager) processFile(path string) File {
 	k8sResources, err := dm.ResourceHelper.NewResourcesFromFilename(path)
 
 	if err != nil {
-		log.Error("Error getting resources: %v\n", err)
+		log.Errorf("Error getting resources: %v\n", err)
 		return File{
 			Name:       path,
 			DiffResult: ErrorDiffStatus(err.Error()),

--- a/cmd/kontrastd/manager.go
+++ b/cmd/kontrastd/manager.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 
@@ -15,23 +15,12 @@ import (
 	"github.com/monzo/kontrast/pkg/k8s"
 )
 
-const (
-	objectLabel = "object"
-	nsLabel     = "object_ns"
-)
-
 type DiffManager struct {
+	mu      *sync.RWMutex
 	LastRun *DiffRun
 	LastErr error
 	*k8s.ResourceHelper
 }
-
-var (
-	currentDiffsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "kontrast_current_diffs",
-		Help: "Number of diffs between manifests and cluster",
-	}, []string{objectLabel, nsLabel})
-)
 
 func (dm *DiffManager) DiffRun(path string) (*DiffRun, error) {
 	d := &DiffRun{
@@ -60,14 +49,34 @@ func (dm *DiffManager) DiffRun(path string) (*DiffRun, error) {
 		return nil
 	})
 
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
 	d.DiffResult = DiffFromNumber(numDiffs)
 	dm.LastRun = d
 	dm.LastErr = err
 	return d, err
 }
 
-func (dm *DiffManager) processFile(path string) File {
+// GetDiffFiles returns the files which have diffs present
+func (dm *DiffManager) GetDiffFiles() []File {
+	dm.mu.RLock()
+	defer dm.mu.RUnlock()
 
+	files := []File{}
+	if dm.LastRun == nil {
+		return files
+	}
+
+	for _, file := range dm.LastRun.Files {
+		if file.DiffResult.Status == DiffPresent {
+			files = append(files, file)
+		}
+	}
+	return files
+}
+
+func (dm *DiffManager) processFile(path string) File {
 	k8sResources, err := dm.ResourceHelper.NewResourcesFromFilename(path)
 
 	if err != nil {
@@ -98,6 +107,7 @@ func (dm *DiffManager) processResource(k8sr *k8s.Resource) Resource {
 	r := Resource{
 		Name:             k8sr.Name,
 		Namespace:        k8sr.Namespace,
+		Kind:             gvk.Kind,
 		GroupVersionKind: fmt.Sprintf("%s.%s", gvk.Version, gvk.Kind),
 	}
 
@@ -111,23 +121,14 @@ func (dm *DiffManager) processResource(k8sr *k8s.Resource) Resource {
 
 	label := fmt.Sprintf("%s/%s", gvk.Kind, r.Name)
 
-	labelledGauge := currentDiffsGauge.With(prometheus.Labels{
-		objectLabel: label,
-		nsLabel:     k8sr.Namespace,
-	})
-
 	switch d.(type) {
 	case diff.NotPresentOnServerDiff:
 		r.IsNewResource = true
 		r.DiffResult.Status = New
 		r.DiffResult.NumDiffs = 1
-		labelledGauge.Set(1)
 
 	case diff.ChangesPresentDiff:
 		r.DiffResult.NumDiffs = len(d.Deltas())
-
-		// Set the gauge when present, reset when the diff is cleared.
-		labelledGauge.Set(float64(r.DiffResult.NumDiffs))
 
 		if len(d.Deltas()) > 0 {
 			r.DiffResult.Status = DiffPresent
@@ -154,11 +155,11 @@ func DiffFromDelta(delta diff.Delta) Diff {
 
 func NewDiffManager(config *rest.Config) (*DiffManager, error) {
 	helper, err := k8s.NewResourceHelperWithDefaults(config)
-	prometheus.MustRegister(currentDiffsGauge)
 	if err != nil {
 		return &DiffManager{}, err
 	}
 	return &DiffManager{
+		mu:             &sync.RWMutex{},
 		ResourceHelper: helper,
 	}, nil
 }

--- a/cmd/kontrastd/types.go
+++ b/cmd/kontrastd/types.go
@@ -52,6 +52,7 @@ type File struct {
 type Resource struct {
 	Name             string
 	Namespace        string
+	Kind             string
 	GroupVersionKind string
 	IsNewResource    bool
 	Diffs            []Diff


### PR DESCRIPTION
As resources get deleted, we are not stopping the emitting of those metrics and instead presenting them as diffs. This means forever until the collector gets booted, we are emitting metrics that there is a diff when there isn't. 

This switches the code to use a dynamic Prometheus collector which is backed by our diff runner