### PR TITLE
De-duplicate dynamic metrics

### DIFF
--- a/cmd/kontrastd/collector.go
+++ b/cmd/kontrastd/collector.go
@@ -18,6 +18,12 @@ var (
 		[]string{objectLabel, nsLabel}, nil)
 )
 
+type labelSet struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
 // KontrastCollector is here to satisfy the Prometheus Collector interface
 type KontrastCollector struct {
 	manager *DiffManager
@@ -40,14 +46,20 @@ func (c *KontrastCollector) Describe(ch chan<- *prometheus.Desc) {
 // metrics. The implementation sends each collected metric via the
 // provided channel and returns once the last metric has been sent.
 func (c *KontrastCollector) Collect(ch chan<- prometheus.Metric) {
+	resources := map[labelSet]float64{}
 	for _, file := range c.manager.GetDiffFiles() {
 		for _, resource := range file.Resources {
 			if resource.DiffResult.Status == DiffPresent {
-				objectLabel := fmt.Sprintf("%s/%s", resource.Kind, resource.Name)
-				ch <- prometheus.MustNewConstMetric(currentDiffsGauge,
-					prometheus.GaugeValue, 1.0,
-					objectLabel, resource.Namespace)
+				ls := labelSet{resource.Kind, resource.Name, resource.Namespace}
+				resources[ls] = resources[ls] + 1
 			}
 		}
+	}
+
+	for resource, _ := range resources {
+		objectLabel := fmt.Sprintf("%s/%s", resource.Kind, resource.Name)
+		ch <- prometheus.MustNewConstMetric(currentDiffsGauge,
+			prometheus.GaugeValue, 1.0,
+			objectLabel, resource.Namespace)
 	}
 }


### PR DESCRIPTION
Some kube manifests define multiple of the same resource. This is
invalid, but shouldn't break kontrast.

Where kontrast meets duplicates, it tries to create the same Gauge
multiple times with the same label set. This results in this error when scraping metrics:

```
An error has occurred during metrics gathering:
2 error(s) occurred:
* collected metric kontrast_current_diffs label:<name:"object" value:"CustomResourceDefinition/verticalpodautoscalers.autoscaling.k8s.io" > label:<name:"object_ns" value:"default" > gauge:<value:1 >  was collected before with the same name and label values
* collected metric kontrast_current_diffs label:<name:"object" value:"CustomResourceDefinition/verticalpodautoscalercheckpoints.autoscaling.k8s.io" > label:<name:"object_ns" value:"default" > gauge:<value:1 >  was collected before with the same name and label values
```

To fix this, we de-duplicate the diffed resources first in a map
before creating metrics.