### PR TITLE
Filter out `additionalPrinterColumns` and `finalizers`

### DIFF
--- a/pkg/diff/filters.go
+++ b/pkg/diff/filters.go
@@ -15,6 +15,7 @@ var filters = []*regexp.Regexp{
 	regexp.MustCompile(`spec.template.metadata.annotations.pod.alpha.kubernetes.io/init-containers`),
 	regexp.MustCompile(`spec.template.metadata.annotations.pod.beta.kubernetes.io/init-containers`),
 	regexp.MustCompile(`spec.template.metadata.annotations.kubectl.kubernetes.io/restartedAt`),
+	regexp.MustCompile(`spec\.additionalPrinterColumns`),
 	regexp.MustCompile(`spec\.jobTemplate\.spec\.backoffLimit`),
 	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.hostPath\.type`),
 	regexp.MustCompile(`spec\.template\.spec\.volumes\.[0-9]+\.emptyDir\.sizeLimit`),

--- a/pkg/diff/filters.go
+++ b/pkg/diff/filters.go
@@ -24,6 +24,7 @@ var filters = []*regexp.Regexp{
 	regexp.MustCompile(`spec\.revisionHistoryLimit`),
 	regexp.MustCompile(`spec\.ports\.[0-9]+\.nodePort`),
 	regexp.MustCompile(`spec\.(clusterIP|volumeName)`),
+	regexp.MustCompile(`spec\.finalizers`),
 	regexp.MustCompile(`secrets`),
 	regexp.MustCompile(`status.*`),
 }


### PR DESCRIPTION
CRDs always have a `creationTimestamp` as part of
`additionalPrinterColumns`. This isn't exposed in the defaults from the
K8s api.

For some namespaces there is a single `kubernetes` finalizer in
the `spec`. Finalizers are normally added as labels. This is a field
controlled by Kubernetes.